### PR TITLE
Enhance driver and communication stealth capabilities

### DIFF
--- a/KM-UM/UM/src/StealthComm.cpp
+++ b/KM-UM/UM/src/StealthComm.cpp
@@ -9,9 +9,59 @@
 // #include <iomanip> // For std::hex, std::setw, std::setfill - Logging should handle formatting
 #include <atomic>  // For g_next_request_id
 #include "Logging.h" // Assuming Logging.h is accessible
+#include <winreg.h> // For registry operations
+#include <string>   // For std::wstring
 
 // Define global variables within the StealthComm namespace
 namespace StealthComm {
+
+    // Helper function to convert NTSTATUS to a more generic error for InitializeStealthComm if needed,
+    // or directly return NTSTATUS. For now, InitializeStealthComm returns NTSTATUS.
+    // #define STATUS_REGISTRY_IO_FAILED ((NTSTATUS)0xC0000218L) // Example, could use existing ones too
+
+    static NTSTATUS ReadDynamicConfigFromRegistry(std::wstring& outDevicePath, ULONG& outIoctlCode) {
+        HKEY hKey;
+        LSTATUS status_reg;
+        const WCHAR* regPath = L"SOFTWARE\\CoreSystemServices\\DynamicConfig";
+        const WCHAR* devicePathValueName = L"DevicePath";
+        const WCHAR* handshakeCodeValueName = L"HandshakeCode";
+
+        status_reg = RegOpenKeyExW(HKEY_LOCAL_MACHINE, regPath, 0, KEY_READ, &hKey);
+        if (status_reg != ERROR_SUCCESS) {
+            LogMessageF("[-] ReadDynamicConfigFromRegistry: Failed to open registry key '%s'. Error: %ld", regPath, status_reg);
+            // Map common Reg errors to NTSTATUS if desired, or return a generic one.
+            // For example, ERROR_FILE_NOT_FOUND -> STATUS_OBJECT_NAME_NOT_FOUND
+            return (status_reg == ERROR_FILE_NOT_FOUND) ? 0xC0000034L : 0xC0000225L; // STATUS_OBJECT_NAME_NOT_FOUND / STATUS_UNSUCCESSFUL
+        }
+
+        WCHAR devicePathBuffer[256]; // Max path length for device paths is usually sufficient
+        DWORD bufferSize = sizeof(devicePathBuffer);
+        status_reg = RegQueryValueExW(hKey, devicePathValueName, nullptr, nullptr, (LPBYTE)devicePathBuffer, &bufferSize);
+        if (status_reg != ERROR_SUCCESS) {
+            LogMessageF("[-] ReadDynamicConfigFromRegistry: Failed to read '%s' value. Error: %ld", devicePathValueName, status_reg);
+            RegCloseKey(hKey);
+            return 0xC0000225L; // STATUS_UNSUCCESSFUL or more specific
+        }
+        // Ensure null termination, though RegQueryValueExW for REG_SZ should handle it if buffer is adequate.
+        devicePathBuffer[(bufferSize / sizeof(WCHAR)) - 1] = L'\0';
+        outDevicePath = devicePathBuffer;
+
+        DWORD ioctlCodeBuffer = 0;
+        bufferSize = sizeof(ioctlCodeBuffer);
+        status_reg = RegQueryValueExW(hKey, handshakeCodeValueName, nullptr, nullptr, (LPBYTE)&ioctlCodeBuffer, &bufferSize);
+        if (status_reg != ERROR_SUCCESS || bufferSize != sizeof(DWORD)) {
+            LogMessageF("[-] ReadDynamicConfigFromRegistry: Failed to read '%s' value or size mismatch. Error: %ld, Size: %lu", handshakeCodeValueName, status_reg, bufferSize);
+            RegCloseKey(hKey);
+            return 0xC0000225L; // STATUS_UNSUCCESSFUL or more specific
+        }
+        outIoctlCode = ioctlCodeBuffer;
+
+        RegCloseKey(hKey);
+        LogMessageF("[+] ReadDynamicConfigFromRegistry: Successfully read DevicePath: '%ls', HandshakeCode: 0x%lX", outDevicePath.c_str(), outIoctlCode);
+        return STATUS_SUCCESS;
+    }
+
+
     // --- START: Slot Index Obfuscation/De-obfuscation Utility (UM) ---
     static uint32_t ObfuscateSlotIndex_UM(uint32_t index, uint32_t key) {
         return index ^ key;
@@ -230,13 +280,23 @@ namespace StealthComm {
     NTSTATUS InitializeStealthComm() {
         if (g_shared_comm_block != nullptr) {
             LogMessage("[-] InitializeStealthComm: Attempted to re-initialize while already active. Call ShutdownStealthComm first.");
-            return 0xC00000AA; // STATUS_ALREADY_INITIALIZED
+            return 0xC00000AA; // STATUS_ALREADY_INITIALIZED (Example NTSTATUS code)
         }
-        // std::random_device rd; // Not needed if mt19937_64 is seeded differently or not used for these specific globals
-        // std::mt19937_64 gen(rd());
+
+        std::wstring dynamicDevicePath;
+        ULONG dynamicIoctlCode;
+        NTSTATUS registryReadStatus = ReadDynamicConfigFromRegistry(dynamicDevicePath, dynamicIoctlCode);
+        if (!NT_SUCCESS(registryReadStatus)) {
+            LogMessageF("[-] InitializeStealthComm: Failed to read dynamic configuration from registry. Status: 0x%lX", registryReadStatus);
+            // Potentially return a more specific error like STATUS_REGISTRY_IO_FAILED or just the propagated status
+            return registryReadStatus; // Propagate the error from registry reading
+        }
+        LogMessage("[+] InitializeStealthComm: Using dynamic config from registry.");
+
+
         // Using GetTickCount64 for seed to avoid potential issues with std::random_device availability/quality in some environments
-        std::mt19937_64 gen(GetTickCount64());
-        std::uniform_int_distribution<uint64_t> distrib(1, UINT64_MAX);
+        std::mt19937_64 gen(GetTickCount64()); // Used for dynamic signatures and BeaconSalt
+        std::uniform_int_distribution<uint64_t> distrib(1, UINT64_MAX); // Ensure non-zero values where needed
 
         do { g_dynamic_signatures_relay_data.dynamic_head_signature = distrib(gen); } while (g_dynamic_signatures_relay_data.dynamic_head_signature == 0);
         do { g_dynamic_signatures_relay_data.dynamic_shared_comm_block_signature = distrib(gen); } while (g_dynamic_signatures_relay_data.dynamic_shared_comm_block_signature == 0);
@@ -310,16 +370,18 @@ namespace StealthComm {
         g_ptr_struct3_um->obfuscation_value1 = (uint64_t)(g_ptr_struct3_um->next_ptr_struct) ^ g_dynamic_signatures_relay_data.dynamic_obfuscation_xor_key;
         g_ptr_struct4_um->obfuscation_value1 = (uint64_t)(g_ptr_struct4_um->data_block) ^ g_dynamic_signatures_relay_data.dynamic_obfuscation_xor_key;
 
+        // Use dynamicDevicePath from registry
         HANDLE hDevice = CreateFileW(
-            HANDSHAKE_DEVICE_SYMLINK_NAME_UM, GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr );
+            dynamicDevicePath.c_str(), GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr );
 
         if (hDevice == INVALID_HANDLE_VALUE) {
-            LogMessageF("[-] InitializeStealthComm: Failed to open handle to KM handshake device. Error: %lu", GetLastError());
+            LogMessageF("[-] InitializeStealthComm: Failed to open handle to KM handshake device using dynamic path '%ls'. Error: %lu", dynamicDevicePath.c_str(), GetLastError());
             ShutdownStealthComm();
-            return STATUS_DEVICE_DOES_NOT_EXIST; // Or a more general error
+            // Map GetLastError() to NTSTATUS if needed, e.g., HRESULT_FROM_WIN32(GetLastError())
+            return 0xC000003BL; // STATUS_OBJECT_PATH_NOT_FOUND or similar
         }
 
-        STEALTH_HANDshake_DATA_UM handshakeData;
+        STEALTH_HANDSHAKE_DATA_UM handshakeData;
         handshakeData.ObfuscatedPtrStruct1HeadUmAddress = (PVOID)g_ptr_struct1_head_um;
         if (g_dynamic_signatures_relay_data.dynamic_obfuscation_xor_key == 0) {
             LogMessage("[-] InitializeStealthComm: dynamic_obfuscation_xor_key is 0. Cannot generate handshake token.");
@@ -327,12 +389,31 @@ namespace StealthComm {
             ShutdownStealthComm();
             return STATUS_INVALID_PARAMETER; // Or a custom error
         }
-        handshakeData.VerificationToken = g_dynamic_signatures_relay_data.dynamic_obfuscation_xor_key;
+        handshakeData.VerificationToken = g_dynamic_signatures_relay_data.dynamic_obfuscation_xor_key; // This is the original value before XORing for relay
         memcpy(handshakeData.BeaconPattern, g_dynamic_signatures_relay_data.beacon, BEACON_PATTERN_SIZE);
+        handshakeData.BeaconSalt = distrib(gen); // Initialize BeaconSalt with a random UINT64
+
+        // XOR the relay data members with BeaconSalt before sending (beacon itself is not XORed here)
+        // The g_dynamic_signatures_relay_data is what's found by KM via AOB scan.
+        // KM will de-XOR these after reading them from memory.
+        // NOTE: The handshakeData.VerificationToken still sends the *original* dynamic_obfuscation_xor_key
+        // which KM uses as a bootstrap XOR key to deobfuscate the pointer chain.
+        // The g_dynamic_signatures_relay_data members are what KM eventually reads after pointer traversal and AOB.
+
+        g_dynamic_signatures_relay_data.dynamic_head_signature ^= handshakeData.BeaconSalt;
+        g_dynamic_signatures_relay_data.dynamic_shared_comm_block_signature ^= handshakeData.BeaconSalt;
+        g_dynamic_signatures_relay_data.dynamic_obfuscation_xor_key ^= handshakeData.BeaconSalt;
+        // The g_dynamic_signatures_relay_data.beacon remains unchanged (not XORed with salt here).
+
+        LogMessageF("[+] InitializeStealthComm: Obfuscating DynamicSignaturesRelay members with BeaconSalt 0x%llX before KM discovery.", handshakeData.BeaconSalt);
+        LogMessageF("    Relay dynamic_head_signature (obfuscated): 0x%llX", g_dynamic_signatures_relay_data.dynamic_head_signature);
+        LogMessageF("    Relay dynamic_shared_comm_block_signature (obfuscated): 0x%llX", g_dynamic_signatures_relay_data.dynamic_shared_comm_block_signature);
+        LogMessageF("    Relay dynamic_obfuscation_xor_key (obfuscated): 0x%llX", g_dynamic_signatures_relay_data.dynamic_obfuscation_xor_key);
+
 
         DWORD bytesReturned = 0;
         BOOL success = DeviceIoControl(
-            hDevice, IOCTL_STEALTH_HANDSHAKE_UM, &handshakeData, sizeof(STEALTH_HANDshake_DATA_UM),
+            hDevice, dynamicIoctlCode, &handshakeData, sizeof(STEALTH_HANDSHAKE_DATA_UM), // Use dynamic IOCTL
             nullptr, 0, &bytesReturned, nullptr );
         CloseHandle(hDevice);
 
@@ -371,489 +452,26 @@ namespace StealthComm {
         return STATUS_SUCCESS;
     }
 
+    // The bool SubmitRequestAndWait has been removed.
 
-    bool SubmitRequestAndWait(
-        CommCommand command, uint64_t target_pid, const uint8_t* params, uint32_t params_size,
-        uint8_t* output_buf, uint32_t& output_size,
-        uint64_t& km_status_code, uint32_t timeout_ms)
-    {
-        if (!g_shared_comm_block) {
-            LogMessageF("[-] SubmitRequestAndWait: Shared communication block not initialized for ReqID %u.", g_next_request_id.load());
-            return false;
-        }
-        if (params_size > MAX_PARAM_SIZE) {
-            LogMessageF("[-] SubmitRequestAndWait: Params size %u too large for ReqID %u.", params_size, g_next_request_id.load());
-            return false;
-        }
-
-        uint32_t request_id = g_next_request_id.fetch_add(1);
-        uint64_t sig_um_runtime = g_dynamic_signatures_relay_data.dynamic_shared_comm_block_signature;
-        uint32_t derived_index_xor_key_um_runtime = (uint32_t)(sig_um_runtime & 0xFFFFFFFF) ^ (uint32_t)(sig_um_runtime >> 32);
-
-        if (g_dynamic_signatures_relay_data.dynamic_shared_comm_block_signature == 0) {
-             LogMessageF("[-] SubmitRequestAndWait: ReqID %u - dynamic_shared_comm_block_signature is 0. Cannot manage slot indices.", request_id);
-            return false;
-        }
-        if (g_dynamic_signatures_relay_data.dynamic_obfuscation_xor_key == 0) {
-             LogMessageF("[-] SubmitRequestAndWait: ReqID %u - dynamic_obfuscation_xor_key is 0. Cannot derive crypto keys.", request_id);
-            return false;
-        }
-
-        uint32_t obfuscated_um_slot_index_read = g_shared_comm_block->um_slot_index;
-        uint32_t current_um_slot_index_plain = DeobfuscateSlotIndex_UM(obfuscated_um_slot_index_read, derived_index_xor_key_um_runtime);
-
-        CommunicationSlot* slot = nullptr;
-        bool slot_found = false;
-        uint32_t actual_slot_index_plain = 0;
-
-        for (int i = 0; i < MAX_COMM_SLOTS; ++i) {
-            uint32_t try_index_plain = (current_um_slot_index_plain + i) % MAX_COMM_SLOTS;
-            SlotStatus current_status_atomic = static_cast<SlotStatus>(InterlockedCompareExchange(
-                reinterpret_cast<volatile LONG*>(&g_shared_comm_block->slots[try_index_plain].status),
-                static_cast<LONG>(SlotStatus::UM_REQUEST_PENDING),
-                static_cast<LONG>(SlotStatus::EMPTY)
-            ));
-
-            if (current_status_atomic == SlotStatus::EMPTY) {
-                slot = &g_shared_comm_block->slots[try_index_plain];
-                actual_slot_index_plain = try_index_plain;
-                slot_found = true;
-                break;
-            } else {
-                 current_status_atomic = static_cast<SlotStatus>(InterlockedCompareExchange(
-                    reinterpret_cast<volatile LONG*>(&g_shared_comm_block->slots[try_index_plain].status),
-                    static_cast<LONG>(SlotStatus::UM_REQUEST_PENDING),
-                    static_cast<LONG>(SlotStatus::UM_ACKNOWLEDGED)
-                ));
-                 if (current_status_atomic == SlotStatus::UM_ACKNOWLEDGED) {
-                    slot = &g_shared_comm_block->slots[try_index_plain];
-                    actual_slot_index_plain = try_index_plain;
-                    slot_found = true;
-                    break;
-                 }
-            }
-        }
-
-        if (!slot_found) {
-            LogMessageF("[-] SubmitRequestAndWait: ReqID %u - No free communication slot available. Start search plain index: %u", request_id, current_um_slot_index_plain);
-            return false;
-        }
-
-        uint8_t current_chacha_key_um[32];
-        DeriveKeys_UM(g_dynamic_signatures_relay_data.dynamic_obfuscation_xor_key, request_id, current_chacha_key_um);
-
-        slot->request_id = request_id;
-        slot->command_id = command;
-        slot->process_id = target_pid;
-
-        GenerateNonce_UM(slot->nonce, sizeof(slot->nonce), request_id);
-
-        // AAD for Request: request_id (4) + command_id (4) + process_id (8) + param_size (4) = 20 bytes
-        uint8_t aad_buffer_request[20];
-        uint32_t current_offset = 0;
-        memcpy(aad_buffer_request + current_offset, &request_id, sizeof(request_id));
-        current_offset += sizeof(request_id);
-        memcpy(aad_buffer_request + current_offset, &command, sizeof(command)); // Use 'command' directly
-        current_offset += sizeof(command);
-        memcpy(aad_buffer_request + current_offset, &target_pid, sizeof(target_pid));
-        current_offset += sizeof(target_pid);
-        memcpy(aad_buffer_request + current_offset, &params_size, sizeof(params_size));
-        current_offset += sizeof(params_size);
-        // Total AAD size for request = current_offset (should be 20)
-
-        if (params && params_size > 0) {
-            // Encrypt in-place for params, then copy to slot->parameters if needed.
-            // Or, if params is read-only, copy to slot->parameters first, then encrypt in slot.
-            // Assuming params can be directly used if not modified, or copied if it's const.
-            // Let's assume slot->parameters is the target for ciphertext.
-            memcpy(slot->parameters, params, params_size); // Copy plaintext to slot first
-            StandardLib_ChaCha20_Encrypt_UM(current_chacha_key_um, slot->nonce, aad_buffer_request, current_offset, slot->parameters, params_size, slot->parameters, slot->mac_tag); // Already mac_tag
-        } else {
-            // Even if params_size is 0, we still need to generate a tag for the AAD
-            StandardLib_ChaCha20_Encrypt_UM(current_chacha_key_um, slot->nonce, aad_buffer_request, current_offset, nullptr, 0, nullptr, slot->mac_tag); // Already mac_tag
-        }
-        slot->param_size = params_size;
-        // StandardLib_Poly1305_MAC_UM is removed. Tag is generated by Encrypt_UM.
-        slot->output_size = 0;
-
-        uint32_t next_um_slot_index_plain = (actual_slot_index_plain + 1) % MAX_COMM_SLOTS;
-        uint32_t obfuscated_next_um_slot_index = ObfuscateSlotIndex_UM(next_um_slot_index_plain, derived_index_xor_key_um_runtime);
-        g_shared_comm_block->um_slot_index = obfuscated_next_um_slot_index;
-
-        DWORD start_time = GetTickCount();
-        bool processed_response = false;
-
-        while (GetTickCount() - start_time < timeout_ms) {
-            SlotStatus current_slot_status_volatile = slot->status;
-            if (current_slot_status_volatile == SlotStatus::KM_COMPLETED_SUCCESS || current_slot_status_volatile == SlotStatus::KM_COMPLETED_ERROR) {
-                if (slot->request_id != request_id) {
-                    LogMessageF("[-] SubmitRequestAndWait: ReqID %u - Mismatched request ID in slot! Expected %u, Got %u. Critical error.", request_id, request_id, slot->request_id);
-                    InterlockedExchange(reinterpret_cast<volatile LONG*>(&slot->status), static_cast<LONG>(SlotStatus::EMPTY));
-                    return false;
-                }
-
-                km_status_code = slot->result_status_code;
-                uint32_t max_output_buf_size = output_size; // Preserve original buffer capacity
-                output_size = 0; // Will be set to actual decrypted data size
-
-                // AAD for Response: slot->request_id (4) + slot->output_size (4) + slot->result_status_code (8) = 16 bytes
-                uint8_t aad_buffer_response[16];
-                uint32_t response_aad_offset = 0;
-                memcpy(aad_buffer_response + response_aad_offset, &slot->request_id, sizeof(slot->request_id));
-                response_aad_offset += sizeof(slot->request_id);
-                memcpy(aad_buffer_response + response_aad_offset, &slot->output_size, sizeof(slot->output_size)); // This is the ENCRYPTED output size from KM
-                response_aad_offset += sizeof(slot->output_size);
-                memcpy(aad_buffer_response + response_aad_offset, &slot->result_status_code, sizeof(slot->result_status_code));
-                response_aad_offset += sizeof(slot->result_status_code);
-                // Total AAD size for response = response_aad_offset (should be 16)
-
-                bool decryption_ok = false;
-                if (slot->output_size > 0) {
-                    // Decrypt in-place in slot->output
-                    decryption_ok = StandardLib_ChaCha20_Decrypt_UM(current_chacha_key_um, slot->nonce, aad_buffer_response, response_aad_offset, slot->output, slot->output_size, slot->output, slot->mac_tag); // Already mac_tag
-                } else {
-                    // If output_size is 0, still need to verify tag against AAD
-                    uint8_t dummy_plaintext; // Decrypt needs a non-null buffer, even for 0 size
-                    decryption_ok = StandardLib_ChaCha20_Decrypt_UM(current_chacha_key_um, slot->nonce, aad_buffer_response, response_aad_offset, nullptr, 0, &dummy_plaintext, slot->mac_tag); // Already mac_tag
-                }
-
-                if (!decryption_ok) {
-                    LogMessageF("[-] SubmitRequestAndWait: ReqID %u - RESPONSE DECRYPTION/TAG VERIFICATION FAILED.", request_id);
-                    km_status_code = 0xC000A002; // STATUS_AUTH_TAG_MISMATCH
-                    // Do not copy output if decryption failed
-                } else {
-                    // Decryption was successful (includes tag verification)
-                    if (current_slot_status_volatile == SlotStatus::KM_COMPLETED_SUCCESS && MY_NT_SUCCESS(km_status_code)) {
-                        if (output_buf && max_output_buf_size > 0 && slot->output_size > 0) {
-                            uint32_t copy_size = min(max_output_buf_size, slot->output_size);
-                            memcpy(output_buf, slot->output, copy_size);
-                            output_size = copy_size; // Set to actual size of data copied to user buffer
-                        } else {
-                            output_size = 0; // No buffer or no data to copy
-                        }
-                    } else {
-                         output_size = 0; // KM reported error, or decryption succeeded but status was bad
-                    }
-                }
-                processed_response = true;
-                break;
-            }
-            Sleep(5);
-        }
-
-        // Zero out the key material after use
-        volatile PVOID p_key = current_chacha_key_um; // Ensure memset is not optimized away
-        memset((PVOID)p_key, 0, sizeof(current_chacha_key_um));
-
-        InterlockedExchange(reinterpret_cast<volatile LONG*>(&slot->status), static_cast<LONG>(SlotStatus::UM_ACKNOWLEDGED));
-
-        if (!processed_response && MY_NT_SUCCESS(km_status_code)) { // Check km_status_code if not processed
-            LogMessageF("[-] SubmitRequestAndWait: ReqID %u - Request timed out, but km_status_code was 0x%llX.", request_id, km_status_code);
-            // If it timed out but KM might have processed it, this is a risky state.
-            // For now, we return false, but this might need more sophisticated handling.
-            return false;
-        } else if (!processed_response) {
-             LogMessageF("[-] SubmitRequestAndWait: ReqID %u - Request timed out.", request_id);
-            return false;
-        }
-
-        return (slot->status == SlotStatus::UM_ACKNOWLEDGED && MY_NT_SUCCESS(km_status_code));
-    }
-
-    // ... (Public API functions: ReadMemory, WriteMemory, GetModuleBase, AobScan, AllocateMemory - UNCHANGED) ...
+    // ... (Public API functions: ReadMemory, WriteMemory, GetModuleBase, AobScan, AllocateMemory - Old bool versions removed) ...
+    // The NTSTATUS (or uintptr_t returning 0 on error) versions are kept.
     // These will now use the updated SubmitRequestAndWait which calls the new crypto placeholders.
-    bool ReadMemory(uint64_t target_pid, uintptr_t address, void* buffer, size_t size, size_t* bytes_read) {
-        if (bytes_read) *bytes_read = 0;
-        if (!buffer || size == 0) {
-            LogMessage("[-] ReadMemory: Invalid buffer or zero size.");
-            return false;
-        }
-
-        uint8_t params[sizeof(uintptr_t) + sizeof(size_t)];
-        uint32_t params_size = 0;
-        Serialize_uint64(params, address);
-        params_size += sizeof(uintptr_t);
-        Serialize_uint64(params + params_size, size);
-        params_size += sizeof(size_t);
-
-        uint8_t* temp_output_buf = new (std::nothrow) uint8_t[static_cast<uint32_t>(size)];
-        if (!temp_output_buf) {
-            LogMessage("[-] ReadMemory: Failed to allocate temporary output buffer.");
-            return false;
-        }
-
-        uint32_t actual_read_by_km = static_cast<uint32_t>(size);
-        uint64_t km_status_code = 0;
-
-        bool success = SubmitRequestAndWait(
-            CommCommand::REQUEST_READ_MEMORY, target_pid, params, params_size,
-            temp_output_buf, actual_read_by_km, km_status_code );
-
-        if (success && MY_NT_SUCCESS(km_status_code)) {
-            if (actual_read_by_km <= size) {
-                if (bytes_read) *bytes_read = actual_read_by_km;
-                memcpy(buffer, temp_output_buf, actual_read_by_km);
-                delete[] temp_output_buf;
-                return true;
-            } else {
-                 LogMessageF("[-] ReadMemory: KM success but returned output_size (%u) > requested size (%zu).", actual_read_by_km, size);
-            }
-        } else if (!MY_NT_SUCCESS(km_status_code)) {
-             LogMessageF("[-] ReadMemory: KM returned error status: 0x%llX for address 0x%p", km_status_code, (void*)address);
-        } else if (!success) {
-            LogMessageF("[-] ReadMemory: SubmitRequestAndWait failed for address 0x%p", (void*)address);
-        }
-        delete[] temp_output_buf;
-        return false;
-    }
-
-    bool WriteMemory(uint64_t target_pid, uintptr_t address, const void* buffer, size_t size, size_t* bytes_written) {
-        if (bytes_written) *bytes_written = 0;
-        if (!buffer || size == 0) {
-            LogMessage("[-] WriteMemory: Invalid buffer or zero size.");
-            return false;
-        }
-        if (size > (MAX_PARAM_SIZE - sizeof(uintptr_t) - sizeof(size_t))) {
-             LogMessageF("[-] WriteMemory: Data size %zu too large for params buffer.", size);
-            return false;
-        }
-
-        uint8_t params[MAX_PARAM_SIZE];
-        uint32_t params_size = 0;
-        Serialize_uint64(params, address);
-        params_size += sizeof(uintptr_t);
-        Serialize_uint64(params + params_size, size);
-        params_size += sizeof(size_t);
-        memcpy(params + params_size, buffer, size);
-        params_size += static_cast<uint32_t>(size);
-
-        uint8_t temp_output_buf[1];
-        uint32_t actual_bytes_written_by_km = 0;
-        uint64_t km_status_code = 0;
-
-        bool success = SubmitRequestAndWait(
-            CommCommand::REQUEST_WRITE_MEMORY, target_pid, params, params_size,
-            temp_output_buf, actual_bytes_written_by_km, km_status_code );
-
-        if (success && MY_NT_SUCCESS(km_status_code)) {
-            if (actual_bytes_written_by_km == size) {
-                if (bytes_written) *bytes_written = actual_bytes_written_by_km;
-                return true;
-            } else {
-                LogMessageF("[-] WriteMemory: KM success but byte count mismatch. KM wrote: %u, expected: %zu", actual_bytes_written_by_km, size);
-                if (bytes_written) *bytes_written = actual_bytes_written_by_km;
-                return false;
-            }
-        }
-        if (!MY_NT_SUCCESS(km_status_code)) {
-             LogMessageF("[-] WriteMemory: KM returned error status: 0x%llX for address 0x%p", km_status_code, (void*)address);
-        } else if (!success) {
-            LogMessageF("[-] WriteMemory: SubmitRequestAndWait failed for address 0x%p", (void*)address);
-        }
-        return false;
-    }
-
-    uintptr_t GetModuleBase(uint64_t target_pid, const wchar_t* module_name) {
-        if (!module_name || module_name[0] == L'\0') {
-            LogMessage("[-] GetModuleBase: Invalid module name.");
-            return 0;
-        }
-        uint8_t params[MAX_PARAM_SIZE];
-        uint32_t params_size = 0;
-        Serialize_wstring(params, module_name, params_size); // This logs truncation errors internally
-        if (params_size == 0 || params_size > MAX_PARAM_SIZE) {
-            // LogMessage("[-] GetModuleBase: Module name too long, empty, or serialization failed."); // Redundant if Serialize_wstring logs
-            return 0;
-        }
-
-        uint8_t output_buf[sizeof(uintptr_t)];
-        uint32_t output_size_in_out = sizeof(uintptr_t);
-        uint64_t km_status_code = 0;
-
-        bool success = SubmitRequestAndWait(
-            CommCommand::REQUEST_GET_MODULE_BASE, target_pid, params, params_size,
-            output_buf, output_size_in_out, km_status_code );
-
-        if (success && MY_NT_SUCCESS(km_status_code)) {
-            if (output_size_in_out == sizeof(uintptr_t)) {
-                 uintptr_t module_base = Deserialize_uint64(output_buf);
-                 return module_base;
-            } else {
-                // Convert module_name to char* for LogMessageF or use a wide string logger if available
-                char narrow_module_name[128];
-                size_t converted_chars = 0;
-                wcstombs_s(&converted_chars, narrow_module_name, sizeof(narrow_module_name), module_name, _TRUNCATE);
-                LogMessageF("[-] GetModuleBase: KM success but output_size (%u) != sizeof(uintptr_t) for module %s.", output_size_in_out, narrow_module_name);
-                return 0;
-            }
-        }
-        if (!MY_NT_SUCCESS(km_status_code) && !(km_status_code == 0xC0000034L /*STATUS_OBJECT_NAME_NOT_FOUND*/ || km_status_code == 0xC0000225L /*STATUS_NOT_FOUND*/ ) ) {
-            char narrow_module_name_err[128];
-            size_t converted_chars_err = 0;
-            wcstombs_s(&converted_chars_err, narrow_module_name_err, sizeof(narrow_module_name_err), module_name, _TRUNCATE);
-            LogMessageF("[-] GetModuleBase: KM returned error status: 0x%llX for module %s", km_status_code, narrow_module_name_err);
-        } else if (!success) {
-            char narrow_module_name_fail[128];
-            size_t converted_chars_fail = 0;
-            wcstombs_s(&converted_chars_fail, narrow_module_name_fail, sizeof(narrow_module_name_fail), module_name, _TRUNCATE);
-            LogMessageF("[-] GetModuleBase: SubmitRequestAndWait failed for module %s", narrow_module_name_fail);
-        }
-        return 0;
-    }
-
-    uintptr_t AobScan(uint64_t target_pid, uintptr_t start_address, size_t scan_size,
-                      const char* pattern, const char* mask,
-                      uint8_t* out_saved_bytes, size_t saved_bytes_size) {
-        UNREFERENCED_PARAMETER(mask);
-
-        if (!pattern || pattern[0] == '\0') {
-            LogMessage("[-] AobScan: Invalid or empty pattern.");
-            return 0;
-        }
-
-        uint8_t params[MAX_PARAM_SIZE];
-        uint32_t current_offset = 0;
-        Serialize_uint64(params + current_offset, start_address);
-        current_offset += sizeof(uintptr_t);
-        Serialize_uint64(params + current_offset, scan_size);
-        current_offset += sizeof(size_t);
-
-        size_t pattern_str_len = strlen(pattern) + 1;
-        if (current_offset + pattern_str_len > MAX_PARAM_SIZE) {
-            LogMessage("[-] AobScan: Pattern string too long for parameters buffer.");
-            return 0;
-        }
-        memcpy(params + current_offset, pattern, pattern_str_len);
-        current_offset += static_cast<uint32_t>(pattern_str_len);
-
-        uint8_t output_buf[sizeof(uintptr_t)];
-        uint32_t output_buf_capacity = sizeof(uintptr_t);
-        uint64_t km_status_code = 0;
-
-        bool success = SubmitRequestAndWait(
-            CommCommand::REQUEST_AOB_SCAN, target_pid, params, current_offset,
-            output_buf, output_buf_capacity, km_status_code );
-
-        if (out_saved_bytes && saved_bytes_size > 0) {
-            memset(out_saved_bytes, 0, saved_bytes_size);
-        }
-
-        if (success && MY_NT_SUCCESS(km_status_code)) {
-            if (output_buf_capacity == sizeof(uintptr_t)) {
-                uintptr_t found_address = Deserialize_uint64(output_buf);
-                return found_address;
-            } else if (output_buf_capacity == 0 && MY_NT_SUCCESS(km_status_code)) {
-                 return 0;
-            } else {
-                LogMessageF("[-] AobScan: KM success but returned unexpected output_size (%u). Expected sizeof(uintptr_t) or 0.", output_buf_capacity);
-                return 0;
-            }
-        }
-        if (!MY_NT_SUCCESS(km_status_code) && !(km_status_code == 0xC0000034L || km_status_code == 0xC0000225L )) {
-            LogMessageF("[-] AobScan: KM returned error status: 0x%llX for pattern \"%s\".", km_status_code, pattern);
-        } else if (!success) {
-             LogMessageF("[-] AobScan: SubmitRequestAndWait failed for pattern \"%s\".", pattern);
-        }
-        return 0;
-    }
-
-    uintptr_t AllocateMemory(uint64_t target_pid, size_t size, uintptr_t hint_address) {
-        if (size == 0) {
-            LogMessage("[-] AllocateMemory: Allocation size cannot be zero.");
-            return 0;
-        }
-        uint8_t params[sizeof(size_t) + sizeof(uintptr_t)]; // Params are: UINT64 size, UINT64 hint_address
-        uint32_t params_size = 0;
-        Serialize_uint64(params, size);
-        params_size += sizeof(uint64_t);
-        Serialize_uint64(params + params_size, hint_address);
-        params_size += sizeof(uint64_t);
-
-        uint8_t output_buf[sizeof(uintptr_t)];
-        uint32_t output_size_in_out = sizeof(uintptr_t);
-        uint64_t km_status_code = 0;
-
-        bool success = SubmitRequestAndWait(
-            CommCommand::REQUEST_ALLOCATE_MEMORY, target_pid, params, params_size,
-            output_buf, output_size_in_out, km_status_code
-        );
-
-        if (success && MY_NT_SUCCESS(km_status_code)) {
-            if (output_size_in_out == sizeof(uintptr_t)) {
-                uintptr_t allocated_address = Deserialize_uint64(output_buf);
-                if (allocated_address != 0) {
-                    return allocated_address;
-                } else {
-                    LogMessageF("[-] AllocateMemory: KM reported success but returned allocated address 0 for size %zu.", size);
-                    return 0;
-                }
-            } else {
-                 LogMessageF("[-] AllocateMemory: KM success but returned unexpected output_size (%u). Expected sizeof(uintptr_t).", output_size_in_out);
-                return 0;
-            }
-        }
-        if (!MY_NT_SUCCESS(km_status_code)) {
-            LogMessageF("[-] AllocateMemory: KM returned error status: 0x%llX for size %zu.", km_status_code, size);
-        } else if(!success) {
-            LogMessageF("[-] AllocateMemory: SubmitRequestAndWait failed for size %zu.", size);
-        }
-        return 0;
-    }
-    // ... (ShutdownStealthComm - UNCHANGED) ...
-    void ShutdownStealthComm() {
-        // This function itself does not log, but the actions it calls (VirtualFree) might have OS-level events.
-        // If verbose logging of shutdown is needed, add LogMessage calls here.
-        if (g_ptr_struct1_head_um) { VirtualFree(g_ptr_struct1_head_um, 0, MEM_RELEASE); g_ptr_struct1_head_um = nullptr; }
-        if (g_ptr_struct2_um) { VirtualFree(g_ptr_struct2_um, 0, MEM_RELEASE); g_ptr_struct2_um = nullptr; }
-        if (g_ptr_struct3_um) { VirtualFree(g_ptr_struct3_um, 0, MEM_RELEASE); g_ptr_struct3_um = nullptr; }
-        if (g_ptr_struct4_um) { VirtualFree(g_ptr_struct4_um, 0, MEM_RELEASE); g_ptr_struct4_um = nullptr; }
-        if (g_shared_comm_block) { VirtualFree(g_shared_comm_block, 0, MEM_RELEASE); g_shared_comm_block = nullptr; }
-    }
-
-    bool FreeMemory(uint64_t target_pid, uintptr_t address, size_t size) {
-        if (address == 0) {
-            LogMessage("[-] FreeMemory: Address cannot be zero.");
-            return false;
-        }
-        // Size is passed to KM, but KM's ZwFreeVirtualMemory with MEM_RELEASE will use 0 for size.
-        // We still send the original allocation size for potential logging or future use if KM changes.
-        uint8_t params[sizeof(uintptr_t) + sizeof(size_t)];
-        uint32_t params_size = 0;
-        Serialize_uint64(params, address);
-        params_size += sizeof(uintptr_t);
-        Serialize_uint64(params + params_size, size);
-        params_size += sizeof(size_t);
-
-        uint8_t output_buf[1]; // No real output expected
-        uint32_t output_size_in_out = 0;
-        uint64_t km_status_code = 0;
-
-        bool success = SubmitRequestAndWait(
-            CommCommand::REQUEST_FREE_MEMORY, target_pid, params, params_size,
-            output_buf, output_size_in_out, km_status_code);
-
-        if (!success || !MY_NT_SUCCESS(km_status_code)) {
-            LogMessageF("[-] FreeMemory: Failed to free memory at address 0x%p. KM Status: 0x%llX", (void*)address, km_status_code);
-            return false;
-        }
-        LogMessageF("[+] FreeMemory: Successfully requested KM to free memory at 0x%p", (void*)address); // Keep debug log for success
-        return true;
-    }
 
     // Note: km_status_code from slot is now directly returned if KM_COMPLETED_ERROR.
     // If timeout or other UM-side issue, specific NTSTATUS codes are returned.
-    NTSTATUS SubmitRequestAndWait( // Changed return type
+    NTSTATUS SubmitRequestAndWait( // This is the NTSTATUS returning version to keep.
         CommCommand command, uint64_t target_pid, const uint8_t* params, uint32_t params_size,
         uint8_t* output_buf, uint32_t& output_size, // output_size is In/Out
-        /*uint64_t& km_status_code,*/ uint32_t timeout_ms) // km_status_code removed from params, will be return value
+        /*uint64_t& km_status_code,*/ uint32_t timeout_ms) // km_status_code already removed from params
     {
         if (!g_shared_comm_block) {
             LogMessageF("[-] SubmitRequestAndWait: Shared communication block not initialized for ReqID %u.", g_next_request_id.load());
-            return STATUS_INVALID_DEVICE_STATE; // Or a custom error
+            return STATUS_INVALID_DEVICE_STATE;
         }
         if (params_size > MAX_PARAM_SIZE) {
-            LogMessageF("[-] SubmitRequestAndWait: Params size %u too large for ReqID %u.", params_size, g_next_request_id.load());
-            return STATUS_INVALID_BUFFER_SIZE; // Or a custom error
+            LogMessageF("[-] SubmitRequestAndWait: Params size %u too large (MAX: %u) for ReqID %u.", params_size, MAX_PARAM_SIZE, g_next_request_id.load());
+            return STATUS_INVALID_BUFFER_SIZE;
         }
 
         uint32_t request_id = g_next_request_id.fetch_add(1);
@@ -972,15 +590,15 @@ namespace StealthComm {
                 response_aad_offset += sizeof(slot->result_status_code);
 
                 bool decryption_ok = false;
-                if (slot->output_size > 0 && slot->output_size <= MAX_OUTPUT_SIZE_KM) { // Check against KM max
-                    decryption_ok = StandardLib_ChaCha20_Decrypt_UM(current_chacha_key_um, slot->nonce, aad_buffer_response, response_aad_offset, slot->output, slot->output_size, slot->output, slot->mac_tag); // Already mac_tag
+                if (slot->output_size > 0 && slot->output_size <= MAX_OUTPUT_SIZE) {
+                    decryption_ok = StandardLib_ChaCha20_Decrypt_UM(current_chacha_key_um, slot->nonce, aad_buffer_response, response_aad_offset, slot->output, slot->output_size, slot->output, slot->mac_tag);
                 } else if (slot->output_size == 0) {
                     uint8_t dummy_plaintext;
-                    decryption_ok = StandardLib_ChaCha20_Decrypt_UM(current_chacha_key_um, slot->nonce, aad_buffer_response, response_aad_offset, nullptr, 0, &dummy_plaintext, slot->mac_tag); // Already mac_tag
-                } else { // output_size > MAX_OUTPUT_SIZE_KM
-                     LogMessageF("[-] SubmitRequestAndWait: ReqID %u - KM returned output_size (%u) > MAX_OUTPUT_SIZE_KM (%u).", request_id, slot->output_size, MAX_OUTPUT_SIZE_KM);
-                     final_status = STATUS_BUFFER_OVERFLOW; // Or similar error
-                     decryption_ok = false; // Cannot proceed with decryption
+                    decryption_ok = StandardLib_ChaCha20_Decrypt_UM(current_chacha_key_um, slot->nonce, aad_buffer_response, response_aad_offset, nullptr, 0, &dummy_plaintext, slot->mac_tag);
+                } else {
+                     LogMessageF("[-] SubmitRequestAndWait: ReqID %u - KM returned output_size (%u) > MAX_OUTPUT_SIZE (%u).", request_id, slot->output_size, MAX_OUTPUT_SIZE);
+                     final_status = STATUS_BUFFER_OVERFLOW;
+                     decryption_ok = false;
                 }
 
 
@@ -1040,13 +658,13 @@ namespace StealthComm {
         // If requested size > MAX_OUTPUT_SIZE, this simple wrapper needs adjustment
         // or the KM needs to handle chunking (which it doesn't currently).
         // For now, assume 'size' will be <= MAX_OUTPUT_SIZE.
-        if (size > MAX_OUTPUT_SIZE_KM) { // Check against KM's max output
-            LogMessageF("[-] ReadMemory: Requested read size %zu exceeds MAX_OUTPUT_SIZE_KM %u.", size, MAX_OUTPUT_SIZE_KM);
+        if (size > MAX_OUTPUT_SIZE) {
+            LogMessageF("[-] ReadMemory: Requested read size %zu exceeds MAX_OUTPUT_SIZE %u.", size, MAX_OUTPUT_SIZE);
             return STATUS_BUFFER_TOO_SMALL;
         }
 
-        uint8_t temp_output_buf[MAX_OUTPUT_SIZE_KM]; // Use KM's max
-        uint32_t actual_read_by_km_or_slot_max = MAX_OUTPUT_SIZE_KM; // Pass max capacity of temp_output_buf
+        uint8_t temp_output_buf[MAX_OUTPUT_SIZE];
+        uint32_t actual_read_by_km_or_slot_max = MAX_OUTPUT_SIZE;
 
         NTSTATUS status = SubmitRequestAndWait(
             CommCommand::REQUEST_READ_MEMORY, target_pid, params, params_size,
@@ -1076,12 +694,12 @@ namespace StealthComm {
             return STATUS_INVALID_PARAMETER;
         }
         // Param buffer for write: address (u64) + size_to_write (u64) + data_itself (up to MAX_PARAM_SIZE - headers)
-        if (size > (MAX_PARAM_SIZE_KM - (sizeof(uintptr_t) + sizeof(size_t)))) {
-             LogMessageF("[-] WriteMemory: Data size %zu too large for params buffer.", size);
+        if (size > (MAX_PARAM_SIZE - (sizeof(uintptr_t) + sizeof(size_t)))) {
+             LogMessageF("[-] WriteMemory: Data size %zu too large for params buffer (MAX: %u).", size, (MAX_PARAM_SIZE - (sizeof(uintptr_t) + sizeof(size_t))));
             return STATUS_BUFFER_TOO_SMALL;
         }
 
-        uint8_t params[MAX_PARAM_SIZE_KM];
+        uint8_t params[MAX_PARAM_SIZE];
         uint32_t params_size = 0;
         Serialize_uint64(params, address);
         params_size += sizeof(uintptr_t);
@@ -1115,22 +733,17 @@ namespace StealthComm {
     uintptr_t GetModuleBase(uint64_t target_pid, const wchar_t* module_name) {
         if (!module_name || module_name[0] == L'\0') {
             LogMessage("[-] GetModuleBase: Invalid module name.");
-            return 0; // Keep returning 0 for error in this specific wrapper for now
-        }
-        uint8_t params[MAX_PARAM_SIZE_KM];
-        uint32_t params_size = 0;
-        // Custom serialization for wstring to ensure it fits and is null-terminated.
-        size_t module_name_len_bytes = (wcslen(module_name) + 1) * sizeof(wchar_t);
-        if (module_name_len_bytes > MAX_PARAM_SIZE_KM) {
-            // Convert module_name to char* for LogMessageF or use a wide string logger if available
-            char narrow_module_name[128]; // Assuming module names are not excessively long
-            size_t converted_chars = 0;
-            wcstombs_s(&converted_chars, narrow_module_name, sizeof(narrow_module_name), module_name, _TRUNCATE);
-            LogMessageF("[-] GetModuleBase: Module name '%s' too long.", narrow_module_name);
             return 0;
         }
-        memcpy(params, module_name, module_name_len_bytes);
-        params_size = static_cast<uint32_t>(module_name_len_bytes);
+        uint8_t params[MAX_PARAM_SIZE];
+        uint32_t params_size = 0;
+
+        Serialize_wstring(params, module_name, params_size); // Serialize_wstring uses MAX_PARAM_SIZE internally
+        if (params_size == 0) {
+            return 0;
+        }
+        // memcpy(params, module_name, module_name_len_bytes); // Done by Serialize_wstring
+        // params_size = static_cast<uint32_t>(module_name_len_bytes); // Done by Serialize_wstring
 
 
         uint8_t output_buf[sizeof(uintptr_t)];
@@ -1176,7 +789,7 @@ namespace StealthComm {
             return 0;
         }
 
-        uint8_t params[MAX_PARAM_SIZE_KM];
+        uint8_t params[MAX_PARAM_SIZE];
         uint32_t current_offset = 0;
         Serialize_uint64(params + current_offset, start_address);
         current_offset += sizeof(uintptr_t);
@@ -1184,8 +797,8 @@ namespace StealthComm {
         current_offset += sizeof(size_t);
 
         size_t pattern_str_len = strlen(pattern) + 1; // Include null terminator
-        if (current_offset + pattern_str_len > MAX_PARAM_SIZE_KM) {
-            LogMessage("[-] AobScan: Pattern string too long for parameters buffer.");
+        if (current_offset + pattern_str_len > MAX_PARAM_SIZE) {
+            LogMessageF("[-] AobScan: Pattern string too long for parameters buffer (MAX: %u).", MAX_PARAM_SIZE);
             return 0;
         }
         memcpy(params + current_offset, pattern, pattern_str_len);


### PR DESCRIPTION
This commit implements a series of enhancements to improve the stealthiness of the kernel-mode driver and its user-mode communication components.

Key changes include:

1.  **Dynamic Communication Parameters:**
    *   Kernel-Mode (KM) now generates a dynamic (random GUID-based) device name
        and symbolic link, and a dynamic handshake IOCTL code upon loading.
    *   These dynamic parameters are written to a predefined registry key.
    *   User-Mode (UM) discovers these parameters by reading from the registry,
        eliminating hardcoded names and IOCTLs for initial connection.

2.  **Beacon and Signature Obfuscation:**
    *   A `BeaconSalt` (random UINT64) is now generated by UM and passed to KM
        during handshake.
    *   KM uses this salt to "salt" the beacon pattern it scans for in UM
        memory, making the scannable beacon unique per session.
    *   Sensitive fields within the `DynamicSignaturesRelay` structure in UM
        (dynamic head signature, shared block signature, obfuscation XOR key)
        are XORed with the `BeaconSalt`. KM de-obfuscates these after reading
        the structure. The beacon field itself within this structure remains
        in its original (unsalted) form for verification after the salted AOB scan.

3.  **Shared Structure Padding:**
    *   Fixed-size padding fields have been added to `CommunicationSlot` and
        `SharedCommBlock` in both KM and UM definitions.
    *   `#pragma pack(push, 1)` is now used in UM for these structures to ensure
        memory layout consistency with KM.

4.  **Minimized Kernel Artifacts:**
    *   The driver object name registered with `IoCreateDriver` is now
        dynamically generated with a random suffix.
    *   Pool tags used in KM (`ExAllocatePoolWithTag`) are now made dynamic
        by XORing static base tags with a runtime-generated random value.

5.  **User-Mode Code Refactoring:**
    *   Resolved inconsistencies in `StealthComm.cpp`, primarily by
        consolidating `SubmitRequestAndWait` to a single `NTSTATUS`-returning
        version and updating all its callers.
    *   Corrected usage of buffer size constants to rely on UM-defined values.

These changes collectively reduce the predictability and detectability of the driver and its communication mechanisms.