### PR TITLE
Refactor: Cleanup debug code and improve documentation

### DIFF
--- a/ResponsibleImGui/Source/ImGui Standalone/UI.cpp
+++ b/ResponsibleImGui/Source/ImGui Standalone/UI.cpp
@@ -242,11 +242,13 @@ void UI::Render()
     int destinyWidth = destinyRect.right - destinyRect.left;
     int destinyHeight = destinyRect.bottom - destinyRect.top;
 
+#ifdef _DEBUG
     std::cout
         << "[Overlay-Create] destinyWindow=" << destinyWindow
         << " Pos=(" << destinyX << "," << destinyY << ")"
         << " Size=" << destinyWidth << "×" << destinyHeight
         << std::endl;
+#endif
     
     // Create overlay window class
     const WNDCLASSEXW wc = { 
@@ -366,6 +368,7 @@ void UI::Render()
                 SetWindowPos(hwnd, HWND_TOPMOST, currentX, currentY, currentWidth, currentHeight, 
                             SWP_NOACTIVATE/* | SWP_NOZORDER*/);
 
+#ifdef _DEBUG
                 RECT overlayRect;
                 if (GetWindowRect(hwnd, &overlayRect)) {
                     std::cout
@@ -377,6 +380,7 @@ void UI::Render()
                         << (overlayRect.bottom - overlayRect.top)
                         << std::endl;
                 }
+#endif
                 
                 lastDestinyRect = currentDestinyRect;
             }
@@ -417,7 +421,11 @@ void UI::Render()
         ImGui_ImplWin32_NewFrame();
         ImGui::NewFrame();
 
-        Drawing::Poll(); // fix for keybinds not working
+        // Drawing::Poll() is called here to process all feature-related inputs and state updates.
+        // This includes polling for hotkey presses (e.g., Fly, AbilityCharge) and updating feature logic accordingly.
+        // Its regular execution in the main loop is crucial for the responsiveness of these features.
+        // Original comment: "fix for keybinds not working"
+        Drawing::Poll();
 
         if (overlayEnabled)
         {
@@ -434,6 +442,9 @@ void UI::Render()
 
         pSwapChain->Present(1, 0);
 
+        // Check if the main ImGui window (controlled by Drawing::bDraw) is still active.
+        // Drawing::isActive() will return false if the user has closed the window.
+        // If not active, break out of the render loop to allow the application/thread to terminate.
 #ifndef _WINDLL
         if (!Drawing::isActive())
             break;


### PR DESCRIPTION
This commit addresses several aspects of code cleanup and documentation:

1.  **Debug Code Removal:**
    *   Conditionalized `std::cout` debug messages in UI.cpp (`[Overlay-Create]`, `[Overlay] Pos: ...`) to only appear in debug builds.
    *   Removed a `std::cout` from `Drawing.cpp` in `PollGameSpeed`.
    *   Note: Further refinement of `LogMessageF` calls in `Drawing.cpp` for debug vs. release was largely skipped due to persistent limitations I encountered when modifying this file.

2.  **Clarified `Drawing::Poll()` "fix":**
    *   Added a detailed comment in `UI.cpp` explaining that `Drawing::Poll()` is essential for processing feature hotkeys and states, and its regular execution is vital for responsiveness.

3.  **Clarified `Drawing::isActive()` Behavior:**
    *   Added comments in `Drawing.cpp` (for `bDraw`, `isActive`, `Active`) and `UI.cpp` (for the loop condition) to explain how the main ImGui window's closure (affecting `bDraw`) correctly leads to the termination of the UI render loop.

4.  **Documentation Added:**
    *   **Kernel Driver (`KM-UM/KM/src/main.cpp`):**
        *   Documented `DiscoveryAndAttachmentThread`, `HandshakeDeviceControl`, `KmPollingWorkItemCallback`.
        *   Explained dynamic configuration (names, IOCTLs, pool tags) and registry persistence.
        *   Clarified the purpose of `PrepareForUnload`.
    *   **Features (`ResponsibleImGui/Source/ImGui Standalone/Features.h`):**
        *   Commented global state variables and key helper functions.
        *   Added brief explanations for each feature namespace and their critical members.
        *   Documented `PerformStartupAobScans` and `PerformStartupByteReads`.
    *   **Drawing Logic (`ResponsibleImGui/Source/ImGui Standalone/Drawing.cpp`):**
        *   Documented `AsyncInitializeSignaturesAndBytes_ThreadFunc`.
        *   Added comprehensive comments for `DisableAndCleanupAllFeatures` and `ResetAllFeatureStates`.
        *   Explained the role of `UpdateFeatureStates` and individual `Poll<FeatureName>` functions.
        *   Commented `DisableViewAngleHook`.
    *   **Deprecated UM CLI (`KM-UM/UM/src/main.cpp`):**
        *   Added inline comments to the Killaura shellcode example for clarity, supplementing the existing deprecation notice.

Overall, these changes improve the maintainability and understanding of the codebase by removing or conditionalizing debug outputs and by adding explanatory comments to critical and complex sections.